### PR TITLE
update HandlerLink() to use current page

### DIFF
--- a/src/Controllers/BetterElementController.php
+++ b/src/Controllers/BetterElementController.php
@@ -36,11 +36,10 @@ class BetterElementController extends ElementController
         $element = $this->getElement();
         $segment = $element->getHandlerURLSegment();
         if (!is_null($segment)) {
-            $curr = Controller::curr();
+            $curr = $element->getPage();
             if (!is_null($curr) && $curr->hasMethod('Link')) {
                 $link = Controller::join_links(
-                    $curr->Link(),
-                    $segment,
+                    $curr->Link($segment),
                     $action
                 );
             }


### PR DESCRIPTION
update `HandlerLink()`
- to use current page instead of current controller (as that might be the element controller, not the page it is used on)
- to inject the segment into the `Link()` method to make sure the page url segment is also added on `'/home`